### PR TITLE
BLD: updates Dockerfile and adds gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,142 @@
 __pycache__
 questions.npy
 questions_len.npy
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,22 @@
 # set base image (host OS)
 FROM python:3.7
 
-ADD app.py /
-
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONIOENCODING=UTF-8
 
 # set the working directory in the container
 WORKDIR /code
 
-# copy the dependencies file to the working directory
-COPY . .
-
 # install dependencies
-RUN pip install -r requirements.txt
+COPY requirements.txt .
+RUN pip install -r ./requirements.txt
 
-# copy the content of the local src directory to the working directory
-# COPY . .
+# copy the dependencies file to the working directory
+COPY app.py bert.py heroku.yml Procfile setup.sh ./
+
+# copy the data (move this higher if the data doesn't change much)
+COPY data ./data
 
 # command to run on container start
+EXPOSE 8501
 CMD [ "python", "./app.py" ]


### PR DESCRIPTION
The Dockerfile updates  take advantage of docker layer caching so that changes in your codebase (e.g. an update to `app.py`) don't necessitate pip installing all of your requirements. The gitignore adds a bunch of python-specific stuff.